### PR TITLE
Add test project and safe config writes

### DIFF
--- a/Line.Tests/ConfigSaveTests.cs
+++ b/Line.Tests/ConfigSaveTests.cs
@@ -1,0 +1,62 @@
+using System;
+using System.IO;
+using System.Reflection;
+using System.Runtime.Serialization;
+using Xunit;
+
+namespace Line.Tests
+{
+    public class ConfigSaveTests
+    {
+        private static void InvokeSave(object instance, string methodName)
+        {
+            var method = instance.GetType().GetMethod(methodName, BindingFlags.NonPublic | BindingFlags.Instance);
+            method!.Invoke(instance, null);
+        }
+
+        private static string GetConfigPath(object instance)
+        {
+            var field = instance.GetType().GetField("configPath", BindingFlags.NonPublic | BindingFlags.Instance);
+            return (string)field!.GetValue(instance)!;
+        }
+
+        private static void TestSaveConfig(Type type)
+        {
+            var instance = FormatterServices.GetUninitializedObject(type);
+            var path = GetConfigPath(instance);
+            var dir = Path.GetDirectoryName(path)!;
+            if (Directory.Exists(dir))
+            {
+                Directory.Delete(dir, true);
+            }
+
+            InvokeSave(instance, "SaveConfig");
+
+            Assert.True(File.Exists(path));
+        }
+
+        [Fact]
+        public void LineForm_SaveConfig_CreatesFile()
+        {
+            TestSaveConfig(typeof(Line.LineForm));
+        }
+
+        [Fact]
+        public void VerticalLineForm_SaveConfig_CreatesFile()
+        {
+            TestSaveConfig(typeof(Line.VerticalLineForm));
+        }
+
+        [Fact]
+        public void HorizontalLineForm_SaveConfig_CreatesFile()
+        {
+            TestSaveConfig(typeof(Line.HorizontalLineForm));
+        }
+
+        [Fact]
+        public void BoundingBoxForm_SaveConfig_CreatesFile()
+        {
+            TestSaveConfig(typeof(Line.BoundingBoxForm));
+        }
+    }
+}

--- a/Line.Tests/Line.Tests.csproj
+++ b/Line.Tests/Line.Tests.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="xunit" Version="2.5.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Line\Line.csproj" />
+  </ItemGroup>
+</Project>

--- a/Line.sln
+++ b/Line.sln
@@ -7,6 +7,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Line", "Line\Line.csproj", 
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Line_wpf", "Line_wpf\Line_wpf.csproj", "{E85B9848-33D5-4485-B729-DBBC2E6D6918}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Line.Tests", "Line.Tests\Line.Tests.csproj", "{33E28D51-9686-4CBC-BC38-A956A4D2F569}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -20,8 +22,12 @@ Global
 		{E85B9848-33D5-4485-B729-DBBC2E6D6918}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{E85B9848-33D5-4485-B729-DBBC2E6D6918}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E85B9848-33D5-4485-B729-DBBC2E6D6918}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{E85B9848-33D5-4485-B729-DBBC2E6D6918}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
+                {E85B9848-33D5-4485-B729-DBBC2E6D6918}.Release|Any CPU.Build.0 = Release|Any CPU
+                {33E28D51-9686-4CBC-BC38-A956A4D2F569}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {33E28D51-9686-4CBC-BC38-A956A4D2F569}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {33E28D51-9686-4CBC-BC38-A956A4D2F569}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {33E28D51-9686-4CBC-BC38-A956A4D2F569}.Release|Any CPU.Build.0 = Release|Any CPU
+        EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection

--- a/Line/BoundingBoxForm.cs
+++ b/Line/BoundingBoxForm.cs
@@ -1191,6 +1191,12 @@ namespace Line
                     WriteIndented = true
                 });
 
+                var configDir = Path.GetDirectoryName(configPath);
+                if (!Directory.Exists(configDir))
+                {
+                    Directory.CreateDirectory(configDir);
+                }
+
                 File.WriteAllText(configPath, jsonString);
             }
             catch

--- a/Line/HorizontalLineForm.cs
+++ b/Line/HorizontalLineForm.cs
@@ -1093,6 +1093,12 @@ namespace Line
                     WriteIndented = true
                 });
 
+                var configDir = Path.GetDirectoryName(configPath);
+                if (!Directory.Exists(configDir))
+                {
+                    Directory.CreateDirectory(configDir);
+                }
+
                 File.WriteAllText(configPath, jsonString);
             }
             catch (Exception ex)

--- a/Line/Program.cs
+++ b/Line/Program.cs
@@ -510,6 +510,12 @@ namespace Line
                     WriteIndented = true
                 });
 
+                var configDir = Path.GetDirectoryName(configPath);
+                if (!Directory.Exists(configDir))
+                {
+                    Directory.CreateDirectory(configDir);
+                }
+
                 File.WriteAllText(configPath, jsonString);
             }
             catch

--- a/Line/VerticalLineForm.cs
+++ b/Line/VerticalLineForm.cs
@@ -933,6 +933,12 @@ namespace Line
                     WriteIndented = true
                 });
 
+                var configDir = Path.GetDirectoryName(configPath);
+                if (!Directory.Exists(configDir))
+                {
+                    Directory.CreateDirectory(configDir);
+                }
+
                 File.WriteAllText(configPath, jsonString);
             }
             catch (Exception ex)


### PR DESCRIPTION
## Summary
- ensure config save routines create directories before writing
- add xUnit test project verifying each SaveConfig writes files
- hook test project into solution

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684edd68e108832f9c99ab4632988829